### PR TITLE
Fixing to reflect act:scene structure in narrator

### DIFF
--- a/living-room/Note.py
+++ b/living-room/Note.py
@@ -9,11 +9,11 @@ def main():
     lease_printed = bool(Checkpoint.check_flag("lease_printed"))
     
     if unpacked == 5:
-        n.path.change(0.6)
+        n.path.change({"act": 0, "scene": 6})
         n.narrate()
         q = narrator.YesNoQuestion({
             "prompt":"Throw away the note", 
-            "outcomes":[0.7, 0.8]
+            "outcomes":[{"act": 0, "scene": 7}, {"act": 0, "scene": 8}]
         })
         n.path.change(q.ask())
         if n.path.scene == 0.7:
@@ -22,15 +22,15 @@ def main():
         return
 
     if bool(Checkpoint.check_flag("note_read")):
-        n.path.change(0.8)
+        n.path.change({"act": 0, "scene": 8})
         n.narrate()
         q = narrator.Question({
             "question": "Is there a certain section you want to read",
             "responses": [
-                {"choice": "unpacking", "outcome": 0.1},
-                {"choice": "lease", "outcome": 0.2},
-                {"choice": "conclusion", "outcome": 0.3},
-                {"choice": "don't read", "outcome": 0.4}
+                {"choice": "unpacking", "outcome": {"act": 0, "scene": 1}},
+                {"choice": "lease", "outcome": {"act": 0, "scene": 2}},
+                {"choice": "conclusion", "outcome": {"act": 0, "scene": 3}},
+                {"choice": "don't read", "outcome": {"act": 0, "scene": 4}}
             ]
         })
         n.path.change(q.ask())
@@ -40,7 +40,7 @@ def main():
     n.narrate()
     q = narrator.YesNoQuestion({
         "question": "Read the note",
-        "outcomes": [0.1, 0.4]
+        "outcomes": [{"act": 0, "scene": 1}, {"act": 0, "scene": 4}]
     })
     n.path.change(q.ask())
     n.narrate()
@@ -49,7 +49,7 @@ def main():
     while n.path.scene < 6:
         q = narrator.YesNoQuestion({
             "question": "Continue reading",
-            "outcomes": [f"0.{n.path.scene}", 0.4]
+            "outcomes": [{"act": 0, "scene": n.path.scene}, {"act": 0, "scene": 4}]
         })
         n.path.change(q.ask())
         n.narrate()

--- a/living-room/dining-room/FragileBox.py
+++ b/living-room/dining-room/FragileBox.py
@@ -17,7 +17,7 @@ def main():
     
     q = narrator.YesNoQuestion({
         "question": "Open the box?",
-        "outcomes": [1.1, 1.8]
+        "outcomes": [{"act": 1, "scene": 1}, {"act": 1, "scene": 8}]
     })
     
     n.path.change(q.ask())
@@ -30,12 +30,12 @@ def main():
     q = narrator.Question({
         "question": "Where will you place the `Printer.py`?",
         "responses": [
-            {"choice": "living-room", "outcome": 1.2},
-            {"choice": "dining-room", "outcome": 1.3},
-            {"choice": "kitchen", "outcome": 1.4},
-            {"choice": "hallway", "outcome": 1.5},
-            {"choice": "bedroom", "outcome": 1.6},
-            {"choice": "office", "outcome": 1.7}
+            {"choice": "living-room", "outcome": {"act": 1, "scene": 2}},
+            {"choice": "dining-room", "outcome": {"act": 1, "scene": 3}},
+            {"choice": "kitchen", "outcome": {"act": 1, "scene": 4}},
+            {"choice": "hallway", "outcome": {"act": 1, "scene": 5}},
+            {"choice": "bedroom", "outcome": {"act": 1, "scene": 6}},
+            {"choice": "office", "outcome": {"act": 1, "scene": 7}}
         ]
     })
 

--- a/living-room/dining-room/FragileBox.py
+++ b/living-room/dining-room/FragileBox.py
@@ -12,7 +12,7 @@ class FragileBox(BoxSpec):
 def main():
     
     n = narrator.Narrator()
-    n.path.change(1)
+    n.path.change({"act": 1, "scene": 0})
     n.narrate()
     
     q = narrator.YesNoQuestion({

--- a/living-room/dining-room/kitchen/UltraHeavyBox.py
+++ b/living-room/dining-room/kitchen/UltraHeavyBox.py
@@ -18,7 +18,7 @@ def main():
     
     q = narrator.YesNoQuestion({
         "question": "Open the box?",
-        "outcomes": [2.1, 2.8]
+        "outcomes": [{"act": 1, "scene": 1}, {"act": 1, "scene": 8}]
     })
     
     n.path.change(q.ask())
@@ -31,12 +31,12 @@ def main():
     q = narrator.Question({
         "question": "Where will you place the `Couch.py`?",
         "responses": [
-            {"choice": "living-room", "outcome": 2.2},
-            {"choice": "dining-room", "outcome": 2.3},
-            {"choice": "kitchen", "outcome": 2.4},
-            {"choice": "hallway", "outcome": 2.5},
-            {"choice": "bedroom", "outcome": 2.6},
-            {"choice": "office", "outcome": 2.7}
+            {"choice": "living-room", "outcome": {"act": 2, "scene": 2}},
+            {"choice": "dining-room", "outcome": {"act": 2, "scene": 3}},
+            {"choice": "kitchen", "outcome": {"act": 2, "scene": 4}},
+            {"choice": "hallway", "outcome": {"act": 2, "scene": 5}},
+            {"choice": "bedroom", "outcome": {"act": 2, "scene": 6}},
+            {"choice": "office", "outcome": {"act": 2, "scene": 7}}
         ]
     })
 

--- a/living-room/dining-room/kitchen/UltraHeavyBox.py
+++ b/living-room/dining-room/kitchen/UltraHeavyBox.py
@@ -13,7 +13,7 @@ class UltraHeavyBox(BoxSpec):
 def main():
 
     n = narrator.Narrator()
-    n.path.change(2)
+    n.path.change({"act": 2, "scene": 0})
     n.narrate()
     
     q = narrator.YesNoQuestion({

--- a/living-room/hallway/bedroom/SinisterLookingBox.py
+++ b/living-room/hallway/bedroom/SinisterLookingBox.py
@@ -17,7 +17,7 @@ def main():
 
     q = narrator.YesNoQuestion({
         "question": "Open the box?",
-        "outcomes": [4.1, 4.8]
+        "outcomes": [{"act": 4, "scene": 1}, {"act": 4, "scene": 8}]
     })
 
     n.path.change(q.ask())
@@ -30,12 +30,12 @@ def main():
     q = narrator.Question({
         "question": "Where will you place the `Toaster.py`?",
         "responses": [
-            {"choice": "living-room", "outcome": 4.2},
-            {"choice": "dining-room", "outcome": 4.3},
-            {"choice": "kitchen", "outcome": 4.4},
-            {"choice": "hallway", "outcome": 4.5},
-            {"choice": "bedroom", "outcome": 4.6},
-            {"choice": "office", "outcome": 4.7}
+            {"choice": "living-room", "outcome": {"act": 4, "scene": 2}},
+            {"choice": "dining-room", "outcome": {"act": 4, "scene": 3}},
+            {"choice": "kitchen", "outcome": {"act": 4, "scene": 4}},
+            {"choice": "hallway", "outcome": {"act": 4, "scene": 5}},
+            {"choice": "bedroom", "outcome": {"act": 4, "scene": 6}},
+            {"choice": "office", "outcome": {"act": 4, "scene": 7}}
         ]
     })
 

--- a/living-room/hallway/bedroom/SinisterLookingBox.py
+++ b/living-room/hallway/bedroom/SinisterLookingBox.py
@@ -12,7 +12,7 @@ class SinisterLookingBox(BoxSpec):
 def main():
     
     n = narrator.Narrator()
-    n.path.change(4)
+    n.path.change({"act": 4, "scene": 0})
     n.narrate()
 
     q = narrator.YesNoQuestion({

--- a/living-room/hallway/bedroom/TubeShapedBox.py
+++ b/living-room/hallway/bedroom/TubeShapedBox.py
@@ -12,7 +12,7 @@ class TubeShapedBox(BoxSpec):
 def main():
 
     n = narrator.Narrator()
-    n.path.change(3)
+    n.path.change({"act": 3, "scene": 0})
     n.narrate()
     
     q = narrator.YesNoQuestion({

--- a/living-room/hallway/bedroom/TubeShapedBox.py
+++ b/living-room/hallway/bedroom/TubeShapedBox.py
@@ -17,7 +17,7 @@ def main():
     
     q = narrator.YesNoQuestion({
         "question": "Open the box?",
-        "outcomes": [3.1, 3.8]
+        "outcomes": [{"act": 3, "scene": 8}, {"act": 3, "scene": 8}]
     })
 
     n.path.change(q.ask())
@@ -30,12 +30,12 @@ def main():
     q = narrator.Question({
         "question": "Where will you place the `GameCylinder.py`?",
         "responses": [
-            {"choice": "living-room", "outcome": 3.2},
-            {"choice": "dining-room", "outcome": 3.3},
-            {"choice": "kitchen", "outcome": 3.4},
-            {"choice": "hallway", "outcome": 3.5},
-            {"choice": "bedroom", "outcome": 3.6},
-            {"choice": "office", "outcome": 3.7}
+            {"choice": "living-room", "outcome": {"act": 3, "scene": 2}},
+            {"choice": "dining-room", "outcome": {"act": 3, "scene": 3}},
+            {"choice": "kitchen", "outcome": {"act": 3, "scene": 4}},
+            {"choice": "hallway", "outcome": {"act": 3, "scene": 5}},
+            {"choice": "bedroom", "outcome": {"act": 3, "scene": 6}},
+            {"choice": "office", "outcome": {"act": 3, "scene": 7}}
         ]
     })
     

--- a/living-room/hallway/office/BeatUpBox.py
+++ b/living-room/hallway/office/BeatUpBox.py
@@ -12,7 +12,7 @@ class BeatUpBox(BoxSpec):
 def main():
 
     n = narrator.Narrator()
-    n.path.change(5.0)
+    n.path.change({"act": 5, "scene": 0})
     n.narrate()
     
     q = narrator.YesNoQuestion({

--- a/living-room/hallway/office/BeatUpBox.py
+++ b/living-room/hallway/office/BeatUpBox.py
@@ -17,7 +17,7 @@ def main():
     
     q = narrator.YesNoQuestion({
         "question": "Open the box?",
-        "outcomes": [5.1, 5.8]
+        "outcomes": [{"act": 5, "scene": 1}, {"act": 5, "scene": 8}]
     })
     
     n.path.change(q.ask())
@@ -30,12 +30,12 @@ def main():
     q = narrator.Question({
         "question": "Where will you place the `busted-tv.py`?",
         "responses": [
-            {"choice": "living-room", "outcome": 5.2},
-            {"choice": "dining-room", "outcome": 5.3},
-            {"choice": "kitchen", "outcome": 5.4},
-            {"choice": "hallway", "outcome": 5.5},
-            {"choice": "bedroom", "outcome": 5.6},
-            {"choice": "office", "outcome": 5.7}
+            {"choice": "living-room", "outcome": {"act": 5, "scene": 2}},
+            {"choice": "dining-room", "outcome": {"act": 5, "scene": 3}},
+            {"choice": "kitchen", "outcome": {"act": 5, "scene": 4}},
+            {"choice": "hallway", "outcome": {"act": 5, "scene": 5}},
+            {"choice": "bedroom", "outcome": {"act": 5, "scene": 6}},
+            {"choice": "office", "outcome": {"act": 5, "scene": 7}}
         ]
     })
 


### PR DESCRIPTION
Similar to the solution, the `narrator` now expects a different structure for `acts` and `scenes` beyond the `float` repr that we used previously. This affects all `5` boxes, and each has been adapted to the new structure.